### PR TITLE
Fix PHP version in composer.json and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: php
 
 matrix:
     include:
-        - php: 7.0
         - php: 7.1
         - php: nightly
-    fast_finish: true
+    fast_finish: trueŻ
     allow_failures:
         - php: nightly
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1",
     "ext-mbstring": "*",
     "league/oauth2-client": "^2.2",
     "doctrine/collections": "^1.4"


### PR DESCRIPTION
Code uses PHP 7.1 constructs, but the minimum required version is defined as 7.0. I increased the version in configs to 7.1.