### PR TITLE
Less permissive Discriminator guard

### DIFF
--- a/src/Provider/ValueObject/UserDiscriminator.php
+++ b/src/Provider/ValueObject/UserDiscriminator.php
@@ -22,6 +22,7 @@ final class UserDiscriminator
      * UserDiscriminator constructor.
      *
      * @param $discriminator
+     * @throws InvalidUserDiscriminatorException
      */
     public function __construct($discriminator)
     {
@@ -48,11 +49,11 @@ final class UserDiscriminator
         if(is_string($discriminator) === false){
             throw new InvalidUserDiscriminatorException("Discriminator has to be a string");
         }
-
-        $length = strlen((string)$discriminator);
-
-        if ($length !== self::LENGTH) {
+        if (strlen((string)$discriminator) !== self::LENGTH) {
             throw new InvalidUserDiscriminatorException("Discriminator must have 4 chars");
+        }
+        if (!is_numeric($discriminator)) {
+            throw new InvalidUserDiscriminatorException("Discriminator must be numeric");
         }
     }
 

--- a/src/Provider/ValueObject/UserDiscriminator.php
+++ b/src/Provider/ValueObject/UserDiscriminator.php
@@ -46,14 +46,8 @@ final class UserDiscriminator
      */
     private function guardDiscriminator($discriminator)
     {
-        if(is_string($discriminator) === false){
-            throw new InvalidUserDiscriminatorException("Discriminator has to be a string");
-        }
-        if (strlen((string)$discriminator) !== self::LENGTH) {
-            throw new InvalidUserDiscriminatorException("Discriminator must have 4 chars");
-        }
-        if (!is_numeric($discriminator)) {
-            throw new InvalidUserDiscriminatorException("Discriminator must be numeric");
+        if (!preg_match('/^\d{4}$/', $discriminator)) {
+            throw new InvalidUserDiscriminatorException("Discriminator must consist of 4 numbers");
         }
     }
 

--- a/tests/Provider/Entity/UserTest.php
+++ b/tests/Provider/Entity/UserTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: piotrmacha
+ * Date: 24/10/2017
+ * Time: 18:17
+ */
+
+namespace Provider\Entity;
+
+
+use Discord\OAuth2\Client\Provider\Entity\User;
+use Discord\OAuth2\Client\Provider\ValueObject\UserDiscriminator;
+use Discord\OAuth2\Client\Provider\ValueObject\UserName;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    public function testIfConstructsAndSerializesToArray()
+    {
+        $username = new UserName('John Doe');
+        $discriminator = new UserDiscriminator('1234');
+
+        $user = new User();
+        $user->setId('ID');
+        $user->setUsername($username);
+        $user->setDiscriminator($discriminator);
+        $user->setAvatar('avatar_link');
+
+        $expected = [
+          'id' => 'ID',
+          'username' => $username,
+          'discriminator' => $discriminator,
+          'avatar' => 'avatar_link'
+        ];
+
+        $this->assertSame($expected, $user->toArray());
+    }
+}

--- a/tests/Provider/ValueObject/UserDiscriminatorTest.php
+++ b/tests/Provider/ValueObject/UserDiscriminatorTest.php
@@ -52,4 +52,11 @@ final class UserDiscriminatorTest extends TestCase
 
         $this->assertTrue($email->isEqualTo(new UserDiscriminator('1234')));
     }
+
+    public function testIfThrowExceptionOnNonNumericValues()
+    {
+        $this->expectException(InvalidUserDiscriminatorException::class);
+
+        new UserDiscriminator('abcd');
+    }
 }


### PR DESCRIPTION
# What was done?
1. Guard to the Discriminator VO that ensures the discriminator consist of numeric characters only (and reduce of cyclomatic complexity)
2. Test for the new guard case of Discriminator
3. Test for `User->toArray()`